### PR TITLE
Reduce binary size by up to 18% with optimal cargo settings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,13 @@ env:
   DEBUG: 'napi:*'
   APP_NAME: 'pinyin'
   MACOSX_DEPLOYMENT_TARGET: '10.13'
+  CARGO_PROFILE_RELEASE_DEBUG: 'false'
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: '1'
+  CARGO_PROFILE_RELEASE_INCREMENTAL: 'false'
+  CARGO_PROFILE_RELEASE_LTO: 'true'
+  CARGO_PROFILE_RELEASE_OPT_LEVEL: 'z'
+  CARGO_PROFILE_RELEASE_PANIC: 'abort'
+  RUSTFLAGS: '-C link-arg=-s'
 
 on:
   push:
@@ -44,14 +51,14 @@ jobs:
               docker pull $DOCKER_REGISTRY_URL/napi-rs/napi-rs/nodejs-rust:lts-debian
               docker tag $DOCKER_REGISTRY_URL/napi-rs/napi-rs/nodejs-rust:lts-debian builder
             build: |
-              docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build -w /build builder yarn build
+              docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build --env RUSTFLAGS --env-file <(env | grep CARGO) -w /build builder yarn build
           - host: ubuntu-20.04
             target: 'x86_64-unknown-linux-musl'
             docker: |
               docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD $DOCKER_REGISTRY_URL
               docker pull $DOCKER_REGISTRY_URL/napi-rs/napi-rs/nodejs-rust:lts-alpine
               docker tag $DOCKER_REGISTRY_URL/napi-rs/napi-rs/nodejs-rust:lts-alpine builder
-            build: docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build -w /build builder yarn build
+            build: docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build --env-file <(env | grep CARGO) -w /build builder yarn build
           - host: macos-latest
             target: 'aarch64-apple-darwin'
             build: yarn build --target=aarch64-apple-darwin
@@ -77,7 +84,7 @@ jobs:
               docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD $DOCKER_REGISTRY_URL
               docker pull ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
               docker tag ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine builder
-            build: docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/pinyin -w /pinyin builder sh -c "yarn build -- --target=aarch64-unknown-linux-musl"
+            build: docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/pinyin --env-file <(env | grep CARGO) -w /pinyin builder sh -c "yarn build -- --target=aarch64-unknown-linux-musl"
           - host: windows-latest
             target: 'aarch64-pc-windows-msvc'
             build: yarn build --target aarch64-pc-windows-msvc
@@ -479,7 +486,7 @@ jobs:
         run: yarn artifacts
 
       - name: List packages
-        run: ls -R ./npm
+        run: ls -Rl ./npm
         shell: bash
 
       - name: Publish


### PR DESCRIPTION
Hello, the `pinyin.*.node` binaries are currently rather large, which is mostly a side effect of the use of Rust.

This PR attempts to reduce the resultant binary size by anywhere from 6% (Windows) to 18% (Linux).

It uses the cargo settings that produce the smallest binary size with its current stable version. Nightly versions support an
unstable `strip=symbols` feature, which could be added in the future, but for now this is injected via `RUSTFLAGS`.

These are the same settings I use for the prebuilt binaries for sharp - see https://github.com/lovell/sharp-libvips/blob/c14a50c749b503793c6df1de5c9924558ce494f2/build/lin.sh#L79-L85

The Docker-based build jobs pass through these `CARGO*` environment variables into the container.

The musl-based environments currently define their own cargo `rustflags` so these are left intact without overriding the value.