### PR TITLE
fix: update postinstall file name

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "src/**",
     "build.rs",
     "Cargo.toml",
-    "postinstall.js"
+    "postinstall.mjs"
   ],
   "napi": {
     "binaryName": "pinyin",


### PR DESCRIPTION
Update postinstall file name to fix npm installs - it's no longer bundled in the package (it still refers to postinstall.js), causing a failed installation