### PR TITLE
fix(pinyin): preserve non-Han tokens in async segmented pinyin

### DIFF
--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -89,6 +89,13 @@ test('issue #244: asyncPinyin with segment should not duplicate', async (t) => {
   )
 })
 
+test('async mixed with segment', async (t) => {
+  t.deepEqual(
+    await asyncPinyin('特殊天-1', { style: PINYIN_STYLE.Plain, segment: true }),
+    ['te', 'shu', 'tian', '-1'],
+  )
+})
+
 test('我,要,排,序 => 序,我,排,要', (t) => {
   const data = '我要排序'.split('')
   const sortedData = data.sort(compare)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,9 +119,9 @@ impl<'task> ScopedTask<'task> for AsyncPinyinTask {
         let input_words = JIEBA.cut(input, false);
         let input_len = input.len();
         let mut output_py: Vec<String> = Vec::with_capacity(input_len);
-        let mut has_pinyin = false;
         let mut non_hans = String::with_capacity(input_len);
         for word in input_words {
+          let mut has_pinyin = false;
           for py in word.word.to_pinyin().flatten() {
             if !non_hans.is_empty() {
               output_py.push(non_hans.clone());


### PR DESCRIPTION
## Bug

In the `SegmentDefault` branch of `AsyncPinyinTask`, `has_pinyin` is declared **outside** the `for word in input_words` loop. Once a word with pinyin sets it to `true`, subsequent non-Han tokens are never collected into `non_hans`.

## Repro

```ts
await asyncPinyin('特殊天-1', { style: PINYIN_STYLE.Plain, segment: true })
// got:  ['te', 'shu', 'tian']      (missing '-1')
// want: ['te', 'shu', 'tian', '-1']
```

The sync version already works correctly (`has_pinyin` resets per word). This only affects the async path.

## Fix

Move `let mut has_pinyin = false;` inside the for-word loop — one-line change in `src/lib.rs`.

## Test

Added `'async mixed with segment'` test covering `'特殊天-1'` with `segment: true`.

`yarn test` passes locally, and lint is clean.