### PR TITLE
fix(pinyin): validate UTF-8 input buffers instead of from_utf8_unchecked

### DIFF
--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -142,3 +142,11 @@ test('reject invalid UTF-8 Buffer in asyncPinyin', async (t) => {
   const invalid = Buffer.from([0xff, 0xfe, 0xff])
   await t.throwsAsync(() => asyncPinyin(invalid), { message: /valid UTF-8/ })
 })
+
+test('accept valid UTF-8 Uint8Array', (t) => {
+  t.deepEqual(pinyin(new TextEncoder().encode('中国')), pinyin('中国'))
+})
+
+test('accept valid UTF-8 Buffer in asyncPinyin', async (t) => {
+  t.deepEqual(await asyncPinyin(Buffer.from('中国')), await asyncPinyin('中国'))
+})

--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -130,3 +130,15 @@ test('能比较 emoji', (t) => {
   t.deepEqual(compare(middle, greater), -1)
   t.deepEqual(compare(greater, middle), 1)
 })
+
+test('reject invalid UTF-8 Uint8Array', (t) => {
+  // 0xFF 0xFE is not valid UTF-8
+  const invalid = new Uint8Array([0xff, 0xfe, 0xff])
+  t.throws(() => pinyin(invalid), { message: /valid UTF-8/ })
+})
+
+test('reject invalid UTF-8 Buffer in asyncPinyin', async (t) => {
+  // 0xFF 0xFE is not valid UTF-8
+  const invalid = Buffer.from([0xff, 0xfe, 0xff])
+  await t.throwsAsync(() => asyncPinyin(invalid), { message: /valid UTF-8/ })
+})

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ impl<'task> ScopedTask<'task> for AsyncPinyinTask {
   type JsValue = Array<'task>;
 
   fn compute(&mut self) -> Result<Self::Output> {
-    let input = get_chars_buffer(&self.input);
+    let input = get_chars_buffer(&self.input)?;
     match self.option {
       PinyinOption::Default => {
         let input_len = input.len();
@@ -367,16 +367,24 @@ fn get_pinyin(input: Pinyin, style: PinyinStyle) -> &'static str {
 fn get_chars<'a>(input: &'a Either<String, &'a [u8]>) -> Result<&'a str> {
   match input {
     Either::A(input) => Ok(input.as_str()),
-    Either::B(input) => Ok(unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(input.as_ptr(), input.len()))
+    Either::B(input) => std::str::from_utf8(input).map_err(|err| {
+      Error::new(
+        Status::InvalidArg,
+        format!("Input buffer must contain valid UTF-8: {err}"),
+      )
     }),
   }
 }
 
-fn get_chars_buffer(input: &Either<String, Buffer>) -> &str {
+fn get_chars_buffer(input: &Either<String, Buffer>) -> Result<&str> {
   match input {
-    Either::A(input) => input.as_str(),
-    Either::B(input) => unsafe { std::str::from_utf8_unchecked(input.as_ref()) },
+    Either::A(input) => Ok(input.as_str()),
+    Either::B(input) => std::str::from_utf8(input.as_ref()).map_err(|err| {
+      Error::new(
+        Status::InvalidArg,
+        format!("Input buffer must contain valid UTF-8: {err}"),
+      )
+    }),
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,11 @@ impl TryFrom<u32> for PinyinStyle {
 
 pub struct AsyncPinyinTask {
   style: PinyinStyle,
-  input: Either<String, Buffer>,
+  // Owned snapshot of the input bytes: a `Buffer` aliases JS-owned memory,
+  // so holding it across the worker thread would let JS mutate the bytes
+  // during `compute` — a data race, and the UTF-8 check in
+  // `get_chars_buffer` could be invalidated between validation and use.
+  input: Either<String, Vec<u8>>,
   option: PinyinOption,
 }
 
@@ -376,10 +380,10 @@ fn get_chars<'a>(input: &'a Either<String, &'a [u8]>) -> Result<&'a str> {
   }
 }
 
-fn get_chars_buffer(input: &Either<String, Buffer>) -> Result<&str> {
+fn get_chars_buffer(input: &Either<String, Vec<u8>>) -> Result<&str> {
   match input {
     Either::A(input) => Ok(input.as_str()),
-    Either::B(input) => std::str::from_utf8(input.as_ref()).map_err(|err| {
+    Either::B(input) => std::str::from_utf8(input).map_err(|err| {
       Error::new(
         Status::InvalidArg,
         format!("Input buffer must contain valid UTF-8: {err}"),
@@ -403,7 +407,10 @@ pub fn async_pinyin(
 
   let task = AsyncPinyinTask {
     style: opt.style.unwrap_or(PinyinStyle::Plain),
-    input,
+    input: match input {
+      Either::A(input) => Either::A(input),
+      Either::B(input) => Either::B(input.as_ref().to_vec()),
+    },
     option,
   };
   Ok(AsyncTask::with_optional_signal(task, signal))


### PR DESCRIPTION
## Soundness fix

Closes #394

## Problem

The public TS API accepts `Buffer` and `Uint8Array` inputs:

```ts
pinyin(input: string | Uint8Array, ...)
asyncPinyin(input: string | Buffer, ...)
```

But the Rust side uses `unsafe std::str::from_utf8_unchecked()` on the byte slice. This is UB if the buffer contains invalid UTF-8 (e.g. `FF FE FF`).

## Fix

Replace `from_utf8_unchecked` with safe `std::str::from_utf8` in both `get_chars` (sync) and `get_chars_buffer` (async). Returns `Error::new(Status::InvalidArg, ...)` for invalid input.

## Tests

- `reject invalid UTF-8 Uint8Array` — sync pinyin with `0xFF 0xFE 0xFF`
- `reject invalid UTF-8 Buffer in asyncPinyin` — async with `0xFF 0xFE 0xFF`

`yarn test` passes locally, and lint is clean.